### PR TITLE
Potential fix for code scanning alert no. 10: Likely overrunning write

### DIFF
--- a/arch/x86/kernel/hpet.c
+++ b/arch/x86/kernel/hpet.c
@@ -728,7 +728,7 @@ static void __init hpet_select_clockevents(void)
 		if (!(hc->boot_cfg & HPET_TN_FSB_CAP))
 			continue;
 
-		sprintf(hc->name, "hpet%d", i);
+		snprintf(hc->name, sizeof(hc->name), "hpet%d", i);
 
 		irq = hpet_assign_irq(hpet_domain, hc, hc->num);
 		if (irq <= 0)


### PR DESCRIPTION
Potential fix for [https://github.com/RC-State/kalisourcecode/security/code-scanning/10](https://github.com/RC-State/kalisourcecode/security/code-scanning/10)

To fix the problem, we should replace the `sprintf` call with `snprintf`, which allows us to specify the maximum number of characters to write, including the null terminator. This will prevent the buffer overflow by ensuring that no more than the buffer's capacity is written.

Specifically, we will change the line `sprintf(hc->name, "hpet%d", i);` to `snprintf(hc->name, sizeof(hc->name), "hpet%d", i);`. This ensures that the formatted string will not exceed the size of `hc->name`, which is 10 bytes.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
