### PR TITLE
Potential fix for code scanning alert no. 9: Unsigned difference expression compared to zero

### DIFF
--- a/mm/vmalloc.c
+++ b/mm/vmalloc.c
@@ -5060,7 +5060,7 @@ static void __init vmap_init_free_space(void)
 	 *  |<--------------------------------->|
 	 */
 	for (busy = vmlist; busy; busy = busy->next) {
-		if ((unsigned long) busy->addr - vmap_start > 0) {
+		if ((unsigned long) busy->addr > vmap_start) {
 			free = kmem_cache_zalloc(vmap_area_cachep, GFP_NOWAIT);
 			if (!WARN_ON_ONCE(!free)) {
 				free->va_start = vmap_start;


### PR DESCRIPTION
Potential fix for [https://github.com/RC-State/kalisourcecode/security/code-scanning/9](https://github.com/RC-State/kalisourcecode/security/code-scanning/9)

To fix the problem, we need to replace the unsigned subtraction and comparison with a direct comparison of the two values. Specifically, we should replace `(unsigned long) busy->addr - vmap_start > 0` with `(unsigned long) busy->addr > vmap_start`. This change ensures that the comparison correctly reflects the intended logic without relying on the properties of unsigned arithmetic.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
